### PR TITLE
Add API Helper Class

### DIFF
--- a/includes/Generic.php
+++ b/includes/Generic.php
@@ -1,18 +1,20 @@
 <?php
 /* This is a generic template for PHPainfree. It doesn't really do much */
 	$Generic = new Generic();
-	
+	include_once 'core/Api.php';
+
 	class Generic {
 		public function title() {
 			global $Painfree;
 			return 'PHPainfree Version ' . $Painfree->Version;
 		}
-	
+
 		public function __construct() {
 			global $Painfree;
-			
+
 			// $this->db = $Painfree->db;
 			$this->route = $Painfree->route;
+			$this->Api = new Api();
 		}
 	}
-	
+

--- a/includes/core/Api.php
+++ b/includes/core/Api.php
@@ -1,0 +1,59 @@
+<?php
+
+class Api {
+
+	/**
+	 * get decoded JSON from php://input if present, otherwide, return $_POST data
+	 */
+	public function getJSON() {
+		if (!empty($_SERVER['CONTENT_TYPE']) && $_SERVER['CONTENT_TYPE'] == 'application/json') {
+			$json = file_get_contents('php://input');
+			$json = json_decode($json, true);
+			return $json;
+		} else {
+			return $_POST;
+		}
+	}
+
+	public function ok($data = []): void {
+		header('HTTP/1.0 200 OK');
+		header('Content-type: application/json');
+		die(json_encode($data));
+	}
+
+	public function created($data = []): void {
+		header('HTTP/1.0 201 CREATED');
+		header('Content-type: application/json');
+		die(json_encode($data));
+	}
+
+	public function download($data, string $type, string $disposition, string $filename): void {
+		header("Content-Type: $type");
+		header("Content-Disposition: $disposition; filename=$filename");
+		die($data);
+	}
+
+	public function error(int $response_code = 500, string $msg = ''): void {
+		if (!empty($msg)) {
+			error_log('API error: ' . $msg);
+		}
+
+		header('Content-type: application/json');
+
+		$response_headers = [
+			400 => 'Bad Request',
+			403 => 'Forbidden',
+			404 => 'Not Found',
+			405 => 'Method Not Allowed',
+			418 => 'I\'m a teapot',
+			500 => 'Internal Server Error',
+		];
+
+		header("HTTP/1.0 $response_code " . $response_headers[$response_code] ?? 'Unknown Error');
+
+		die(json_encode([
+			'message'  => $msg ?? '',
+			'status'   => $response_code,
+		]));
+	}
+}


### PR DESCRIPTION
## Background

Like many things in this world, PHPainfree's greatest strength is also its greatest weakness: it doesn't do much. It tackles only the most basic aspects of application structure and design, which makes it incredibly flexible and unopinionated, but also requires a great deal of repetitive boilerplate for common tasks, like serving common http responses.

## API Helper class

### Example Usage

```php
$input = $Generic->Api->getJSON();
// do some stuff
$Generic->Api->ok($data);
```
instead of:

```php
if (!empty($_SERVER['CONTENT_TYPE']) && $_SERVER['CONTENT_TYPE'] == 'application/json') {
	$input = file_get_contents('php://input');
	$input = json_decode($json, true);
} else {
	$input = $_POST;
}
// do some stuff
header('HTTP/1.0 200 OK');
header('Content-Type: application/json');
die(json_encode($data));
```

### Benefits

In the twelve years since PHPainfree's inception, much of web architecture has come to rely on decoupled front-ends that interact with the back end via json APIs. This `Api` class provides a few simple helper methods to handle common API requests and responses.

The benefits of these few simple functions are legion:

1. Increases development velocity and code readability by reducing boilerplate for common functions: reading json input and providing json responses - the de facto data format for modern APIs.
2. Reduces errors and inconsistencies potentially introduced by programmers repeatedly re-writing the same boilerplate code.
3. Enables a variety of new functionality (like performance profiling, logging, etc.) by creating a single point of exit for API responses.

This class is provided as a recommended core class, but in the spirit of PHPainfree, can be entirely avoided by not including it in the application's singleton.

