### PR TITLE
Add MySQLi DB Helper Class

### DIFF
--- a/includes/Generic.php
+++ b/includes/Generic.php
@@ -1,18 +1,19 @@
 <?php
 /* This is a generic template for PHPainfree. It doesn't really do much */
 	$Generic = new Generic();
-	
+
 	class Generic {
 		public function title() {
 			global $Painfree;
 			return 'PHPainfree Version ' . $Painfree->Version;
 		}
-	
+
 		public function __construct() {
 			global $Painfree;
-			
-			// $this->db = $Painfree->db;
+
+			// require_once 'core/MySqliHelpers.php';
+			// $this->db = new MySqliHelpers($Painfree->db);
 			$this->route = $Painfree->route;
 		}
 	}
-	
+

--- a/includes/core/MySQLiHelpers.php
+++ b/includes/core/MySQLiHelpers.php
@@ -1,0 +1,63 @@
+<?php
+
+class MySQLiHelpers {
+	private $db = null;
+
+	public function __construct(\mysqli $conn) {
+		$this->db = $conn;
+	}
+
+	/**
+	 * helper function for MySQLi db queries
+	 *
+	 * @param string $query
+	 * @param string|null $types
+	 * @param array|null $params
+	 * @param bool $one
+	 * @return mixed an associative array of results for selects, affected rows for updates, insert_id for inserts and null on any error
+	 */
+	public function query(string $query, string $types = null, array $params = null, bool $single = false) {
+		try {
+			if (!$this->db) {
+				throw new \Exception('no database connection established');
+			}
+
+			if (($types || $params) && strlen($types) !== count($params)) {
+				throw new \Exception('db query error: type/param mismatch');
+			}
+
+			$stmt = $this->db->prepare($query);
+
+			if (!$stmt) {
+				throw new \Exception($this->db->error);
+			}
+
+			if (!empty($types) && !empty($params)) {
+				$stmt->bind_param($types, ...$params);
+			}
+
+			$stmt->execute();
+
+			if (preg_match('/^INSERT/i', $query)) {
+				$data = $stmt->insert_id;
+			} else if (preg_match('/^SELECT/i', $query)) {
+				$data = $single
+					? $stmt->get_result()->fetch_array(MYSQLI_ASSOC)
+					: $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+			} else {
+				$data = $stmt->affected_rows;
+			}
+
+			$stmt->close();
+			return $data;
+		} catch (\Exception $e) {
+			error_log($e->getMessage() . $query);
+		}
+		return null;
+	}
+
+	// get a single result as an associative array for selects
+	public function queryOne(string $query, string $types = null, array $params = null) {
+		return $this->query($query, $types, $params, true);
+	}
+}


### PR DESCRIPTION
## Background

Like many things in this world, PHPainfree's greatest strength is also its greatest weakness: it doesn't do much. It tackles only the most basic aspects of application structure and design, which makes it incredibly flexible and unopinionated, but also requires a great deal of repetitive boilerplate for common tasks, like making database queries.

## MySQLi DB Helper class

### Example Usage

```php
$query = 'SELECT id, name, description FROM data_table WHERE id = ?;';
$results = $Generic->db->query($query, 'i', [$id]);
```
instead of:

```php
$query = 'SELECT id, name, description FROM data_table WHERE id = ?;';
$results = [];
if ($stmt = $Painfree->db->prepare($query)) {
	$stmt->bind_param('i', $id);
	$stmt->execute();
	$stmt->bind_result($id, $name, $description);

	while ($stmt->fetch()) {
		$results[] = [
			'id'          => $id,
			'name'        => $name,
			'description' => $description
		];
	}
	$stmt->close();
} else {
	$stmt->close();
	die($Painfree->db->error);
}
```

### Benefits

While simply exposing the MySQLi object is simple and versatile, it is not at all scalable. The boilerplate involved in using MySQLi directly introduces unnecessary overhead and errors which can be easily abstracted away for 99% of database queries with a couple simple functions.

The benefits of these two simple functions are legion:

1. Increases development velocity and code readability by dramatically reducing boilerplate code for nearly all database queries.
2. Enables a wide range of new functionality (like performance profiling, slow query logging, advanced error checking, offloading certain queries to secondary database endpoints) by creating a single point of entry for all database queries.
3. Reduces errors and inconsistencies potentially introduced by programmers repeatedly re-writing the same boilerplate code. One common example is forgetting to close a connection, or closing that connection improperly, like in the real-life example below:

![Screenshot from 2022-03-03 11-06-08](https://user-images.githubusercontent.com/30528226/156614772-000473b8-efec-4306-a5c8-4caa2d2d9fbe.png)

This class is provided as a recommended core class, but in the spirit of PHPainfree, can be entirely avoided by not including it in the application's singleton.
